### PR TITLE
Add support for Community Tech Tree

### DIFF
--- a/GameData/JFJohnny5/Parts/K2_CommandPod/MM_CommunityTechTree.cfg
+++ b/GameData/JFJohnny5/Parts/K2_CommandPod/MM_CommunityTechTree.cfg
@@ -1,0 +1,4 @@
+@PART[K2Pod]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = simpleCommandModules
+}


### PR DESCRIPTION
When Community Tech Tree is installed, the K2 Command Pod will be placed under the Simple Command Modules tech tree node. This makes a little more sense gameplay-wise, since one would probably develop a 2-seat command module before a 3-seater, not at the same time.